### PR TITLE
Correctif : saturation_rea_journ + lisible

### DIFF
--- a/src/france/covid19_departements_dashboards.py
+++ b/src/france/covid19_departements_dashboards.py
@@ -1916,8 +1916,11 @@ def saturation_rea_journ(dep):
                 size=20
                 ),
             opacity=1,
-            ax=-250,
-            ay=-70,
+            axref="x",
+            ayref="y",
+            ax=dates[len(dates)//2],
+            ay=min(df_saturation.values, key=lambda df_saturation_list : abs(df_saturation_list - df_saturation.max()//2)),
+            bgcolor="rgba(255, 255, 255, 0.6)",
             arrowcolor=colors_sat[-1],
             arrowsize=1.5,
             arrowwidth=1,


### PR DESCRIPTION
Bonjour,

Les graphes de l'occupation rea chevauchent souvent les titres et informations (sources). Par exemple : la Guadeloupe, la Gironde, la Guyanne... Je propose donc ce petit correctif mineur qui centre l'annotation et ajoute un fond blanc. 
J'ai tenté de le faire plus propre, mais plotly est assez restreint pour ce genre de besoin. Le correctif a été testé sur tous les départements, rien à signaler. 

Avant correctif : 
![saturation_rea_journ_Guyane](https://user-images.githubusercontent.com/22295201/118872005-6caafa00-b8e8-11eb-9084-818bc2612a1b.jpeg)
Après correctif ; 
![saturation_rea_journ_Guyane](https://user-images.githubusercontent.com/22295201/118873097-9fa1bd80-b8e9-11eb-889d-995e2b5468b2.jpeg)



- [x]  bg color

- [x]  center annotation text